### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
     needs: [build, provenance]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - name: Download linux binary
         uses: actions/download-artifact@v4.3.0


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/filegram/security/code-scanning/3](https://github.com/PKopel/filegram/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `release` job, specifying the minimal permissions required for its tasks. Based on the job's actions:
- `contents: read` is needed to download artifacts.
- `contents: write` is required to upload release assets.

The `permissions` block will be added under the `release` job definition, ensuring that the `GITHUB_TOKEN` has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
