### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/filegram/security/code-scanning/2](https://github.com/PKopel/filegram/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow. Since the workflow only performs read operations (e.g., checking out the repository and running tests), we will set `contents: read`. This ensures that the workflow has only the permissions it needs and no unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
