### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     outputs:
       hash-linux: ${{ steps.hash.outputs.hash }}
       hash-macos: ${{ steps.hash-mac.outputs.hash }}


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/filegram/security/code-scanning/1](https://github.com/PKopel/filegram/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job. Based on the tasks performed in the `build` job, the following permissions are required:
- `contents: read` to check out the repository code.
- `contents: write` to upload artifacts.

This change will ensure that the `GITHUB_TOKEN` used in the `build` job has only the necessary permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
